### PR TITLE
[fix] pin logging-mp to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8,<3.12"
 dependencies = [
-    "logging_mp",
+    "logging-mp==0.1.6",
     "opencv-python",
     "numpy>=1.21,<2",
     "pyyaml",


### PR DESCRIPTION
Imports of logging-mp relies on the `get_logger` naming which is only available in <= v0.1.6. 
Thus this PR pins logging-mp to 0.1.6 