### PR TITLE
Fix TeleImage.__iter__ yielding fields in the wrong order

### DIFF
--- a/src/teleimager/client.py
+++ b/src/teleimager/client.py
@@ -363,9 +363,9 @@ class TeleImage:
 
     def __iter__(self):
         """ Allow unpacking like: jpg, bgr, fps = teleimage_instance """
-        yield self.fps
         yield self.jpg
         yield (None if self._bgr is TeleImage._NOT_SET else self._bgr)
+        yield self.fps
 
     def __repr__(self):
         """ String representation for debugging """


### PR DESCRIPTION
## Problem

`TeleImage.__iter__` documents tuple-unpacking as:

```python
""" Allow unpacking like: jpg, bgr, fps = teleimage_instance """
```

but yields the fields in a different order:

```python
def __iter__(self):
    """ Allow unpacking like: jpg, bgr, fps = teleimage_instance """
    yield self.fps
    yield self.jpg
    yield (None if self._bgr is TeleImage._NOT_SET else self._bgr)
```

So a user who follows the documented usage gets every value bound to the wrong field:

```python
img = TeleImage(fps=30.0, jpg=b"...", bgr=some_ndarray)
jpg, bgr, fps = img
# jpg -> 30.0            (the fps float)
# bgr -> b"..."          (the jpg bytes)
# fps -> some_ndarray    (the decoded image)
```

## Fix

Yield `jpg, bgr, fps` so `__iter__` matches its own docstring. This also matches the field order declared in `__slots__ = ['jpg', '_bgr', 'fps']`; the previous order followed the `__init__` parameter order `(fps, jpg, bgr)` instead.

```python
def __iter__(self):
    """ Allow unpacking like: jpg, bgr, fps = teleimage_instance """
    yield self.jpg
    yield (None if self._bgr is TeleImage._NOT_SET else self._bgr)
    yield self.fps
```

After the change, `jpg, bgr, fps = img` binds each name correctly.

If the intended contract was actually `fps, jpg, bgr`, the alternative fix would be to update the docstring instead — happy to switch to that if you prefer, but the `__slots__` order suggests `jpg, bgr, fps` was intended.
